### PR TITLE
Add Support for `testnet05`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ COPY run-chainweb-node.sh .
 COPY initialize-db.sh .
 COPY chainweb.mainnet01.yaml .
 COPY chainweb.testnet04.yaml .
+COPY chainweb.testnet05.yaml .
 COPY chainweb.development.yaml .
 COPY check-health.sh .
 RUN chmod 755 run-chainweb-node.sh initialize-db.sh check-health.sh
@@ -50,6 +51,7 @@ RUN chmod 755 run-chainweb-node.sh initialize-db.sh check-health.sh
 RUN mkdir -p /data/chainweb-db \
     mkdir -p /root/.local/share/chainweb-node/mainnet01/ \
     mkdir -p /root/.local/share/chainweb-node/testnet04/ \
+    mkdir -p /root/.local/share/chainweb-node/testnet05/ \
     mkdir -p /root/.local/share/chainweb-node/development/
 
 # Command

--- a/chainweb.testnet05.yaml
+++ b/chainweb.testnet05.yaml
@@ -1,0 +1,74 @@
+databaseDirectory: /data/chainweb-db
+resetChainDatabases: false
+chainweb:
+  throttling:
+    local: 0.1
+    mining: 2
+    global: 200.0
+    putPeer: 21
+  chainwebVersion: testnet05
+  mining:
+    coordination:
+      enabled: false
+      mode: private
+      limit: 1200
+      miners: []
+    nodeMining:
+      enabled: false
+  p2p:
+    peerDbFilePath: null
+    peer:
+      certificateChainFile: null
+      key: null
+      interface: "*"
+      certificateChain: null
+      hostaddress:
+        hostname: "0.0.0.0"
+        port: 443
+      keyFile: null
+    maxPeerCount: 100
+    private: false
+    ignoreBootstrapNodes: false
+    maxSessionCount: 6
+    sessionTimeout: 300
+  transactionIndex:
+    enabled: true
+    configuration: {}
+  headerStream: false
+  mempoolP2p:
+    enabled: true
+    configuration:
+      pollInterval: 30
+      maxSessionCount: 5
+      sessionTimeout: 300
+  reintroTxs: true
+  cuts:
+    pruneChainDatabase: true
+    fetchTimeout: 3000000
+    initialCutHeightLimit: null
+  rosetta: true
+logging:
+  telemetryBackend:
+    enabled: true
+    configuration:
+      handle: stderr
+      color: auto
+      format: text
+  backend:
+    handle: stderr
+    color: auto
+    format: text
+  logger:
+    log_level: warn
+    queue_size: 1000
+    exception_wait: 1000
+    exit_timeout: 1000000
+    scope: []
+    exception_limit: 10
+    policy: discard
+  clusterId: docker-node
+  amberdataBackend:
+    enabled: false
+  filter:
+    rules: []
+    default: debug


### PR DESCRIPTION
- Added a default configuration file for `testnet05`.  
- Updated the `Dockerfile` to include the respective commands for `testnet05`.  
- Introduced `testnet05` as an additional network for now, but it may potentially replace `testnet04` in the future.  
